### PR TITLE
Remove namespace from ClusterRole and ClusterRoleBinding

### DIFF
--- a/charts/kubecollector/templates/rbac/runtime-clusterrole.yaml
+++ b/charts/kubecollector/templates/rbac/runtime-clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "lightspin-kubecollector.runtime.falco.fullname" . }}
-{{ include "lightspin-kubecollector.namespace" . | indent 2 }}
   labels:
     {{- include "lightspin-kubecollector.runtime.falco.labels" . | nindent 4 }}
 rules:

--- a/charts/kubecollector/templates/rbac/runtime-clusterrolebinding.yaml
+++ b/charts/kubecollector/templates/rbac/runtime-clusterrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "lightspin-kubecollector.runtime.falco.serviceAccountName" . }}
-{{ include "lightspin-kubecollector.namespace" . | indent 4 }}
 roleRef:
   kind: ClusterRole
   name: {{ template "lightspin-kubecollector.runtime.falco.fullname" . }}

--- a/charts/kubecollector/templates/rbac/worker-clusterrole.yaml
+++ b/charts/kubecollector/templates/rbac/worker-clusterrole.yaml
@@ -2,7 +2,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: lightspin-secaudit
-{{ include "lightspin-kubecollector.namespace" . | indent 2 }}
 rules:
   - apiGroups: ["*"]
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations", "customresourcedefinitions", "apiservices", "controllerrevisions", "daemonsets", "deployments", "replicasets", "statefulsets", "horizontalpodautoscalers", "cronjobs", "jobs", "certificatesigningrequests", "leases", "endpointslices", "events", "flowschemas", "prioritylevelconfigurations", "nodes", "pods", "storagestates", "storageversionmigrations", "ingressclasses", "ingresses", "networkpolicies", "runtimeclasses", "poddisruptionbudgets", "podsecuritypolicies", "clusterrolebindings", "clusterroles", "rolebindings", "roles", "priorityclasses", "volumesnapshotclasses", "volumesnapshotcontents", "volumesnapshots", "csidrivers", "csinodes", "storageclasses", "volumeattachments", "csistoragecapacities", "componentstatuses", "configmaps", "endpoints", "events", "limitranges", "namespaces", "nodes", "persistentvolumeclaims", "persistentvolumes", "pods", "podtemplates", "replicationcontrollers", "resourcequotas", "serviceaccounts", "services"]

--- a/charts/kubecollector/templates/rbac/worker-clusterrolebinding.yaml
+++ b/charts/kubecollector/templates/rbac/worker-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "lightspin-kubecollector.worker.serviceAccountName" . }}
-{{ include "lightspin-kubecollector.namespace" . | indent 4 }}
+
     apiGroup: ""
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION

ClusterRole and ClusterRoleBinding are global and do not belong to namespaces. 

https://kubernetes.io/docs/reference/access-authn-authz/rbac/#clusterrole-example
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#clusterrolebinding-example

We use Anthos ConfigSync and it is not able to apply the inflated chart because of this violation
